### PR TITLE
スマホでバー展開時、てっぺんが画面外に行かないようにした

### DIFF
--- a/src/container/AudioControllerContainer.tsx/AudioControllerContainer.tsx
+++ b/src/container/AudioControllerContainer.tsx/AudioControllerContainer.tsx
@@ -83,6 +83,7 @@ const StreachAppBar = styled(AppBar)`
   background-color: var(--marine-sub-color);
   &.expand {
     height: auto;
+    max-height: 90vh;
   }
 `;
 


### PR DESCRIPTION
ラベルの長さ次第では履歴表示数が減るけど詰むよりはマシという説